### PR TITLE
add HB-UNI-RGB-LED-CTRL descriptions

### DIFF
--- a/pydevccu/device_descriptions/HB-UNI-RGB-LED-CTRL.json
+++ b/pydevccu/device_descriptions/HB-UNI-RGB-LED-CTRL.json
@@ -1,0 +1,95 @@
+[
+  {
+    "ADDRESS": "VCU3203533",
+    "CHILDREN": [
+      "VCU3203533:0",
+      "VCU3203533:1",
+      "VCU3203533:2",
+      "VCU3203533:3"
+    ],
+    "FIRMWARE": "2.5",
+    "FLAGS": 1,
+    "INTERFACE": "QEQ0689800",
+    "PARAMSETS": [
+      "MASTER"
+    ],
+    "PARENT": "",
+    "RF_ADDRESS": 15941889,
+    "ROAMING": 0,
+    "RX_MODE": 1,
+    "TYPE": "HB-UNI-RGB-LED-CTRL",
+    "UPDATABLE": 1,
+    "VERSION": 1
+  },
+  {
+    "ADDRESS": "VCU3203533:0",
+    "AES_ACTIVE": 0,
+    "DIRECTION": 0,
+    "FLAGS": 3,
+    "INDEX": 0,
+    "LINK_SOURCE_ROLES": "",
+    "LINK_TARGET_ROLES": "",
+    "PARAMSETS": [
+      "MASTER",
+      "VALUES"
+    ],
+    "PARENT": "VCU3203533",
+    "PARENT_TYPE": "HB-UNI-RGB-LED-CTRL",
+    "TYPE": "MAINTENANCE",
+    "VERSION": 1
+  },
+  {
+    "ADDRESS": "VCU3203533:1",
+    "AES_ACTIVE": 0,
+    "DIRECTION": 2,
+    "FLAGS": 1,
+    "INDEX": 1,
+    "LINK_SOURCE_ROLES": "",
+    "LINK_TARGET_ROLES": "SWITCH WCS_TIPTRONIC_SENSOR WEATHER_CS",
+    "PARAMSETS": [
+      "LINK",
+      "MASTER",
+      "VALUES"
+    ],
+    "PARENT": "VCU3203533",
+    "PARENT_TYPE": "HB-UNI-RGB-LED-CTRL",
+    "TYPE": "DIMMER",
+    "VERSION": 1
+  },
+  {
+    "ADDRESS": "VCU3203533:2",
+    "AES_ACTIVE": 0,
+    "DIRECTION": 2,
+    "FLAGS": 1,
+    "INDEX": 2,
+    "LINK_SOURCE_ROLES": "",
+    "LINK_TARGET_ROLES": "SWITCH WCS_TIPTRONIC_SENSOR WEATHER_CS",
+    "PARAMSETS": [
+      "LINK",
+      "MASTER",
+      "VALUES"
+    ],
+    "PARENT": "VCU3203533",
+    "PARENT_TYPE": "HB-UNI-RGB-LED-CTRL",
+    "TYPE": "RGBW_COLOR",
+    "VERSION": 1
+  },
+  {
+    "ADDRESS": "VCU3203533:3",
+    "AES_ACTIVE": 0,
+    "DIRECTION": 2,
+    "FLAGS": 1,
+    "INDEX": 3,
+    "LINK_SOURCE_ROLES": "",
+    "LINK_TARGET_ROLES": "SWITCH WCS_TIPTRONIC_SENSOR WEATHER_CS",
+    "PARAMSETS": [
+      "LINK",
+      "MASTER",
+      "VALUES"
+    ],
+    "PARENT": "VCU3203533",
+    "PARENT_TYPE": "HB-UNI-RGB-LED-CTRL",
+    "TYPE": "RGBW_AUTOMATIC",
+    "VERSION": 1
+  }
+]

--- a/pydevccu/paramset_descriptions/HB-UNI-RGB-LED-CTRL.json
+++ b/pydevccu/paramset_descriptions/HB-UNI-RGB-LED-CTRL.json
@@ -1,0 +1,1794 @@
+{
+  "VCU3203533": {},
+  "VCU3203533:0": {
+    "MASTER": {},
+    "VALUES": {
+      "AES_KEY": {
+        "DEFAULT": 0,
+        "FLAGS": 0,
+        "ID": "AES_KEY",
+        "MAX": 127,
+        "MIN": 0,
+        "OPERATIONS": 1,
+        "TAB_ORDER": 9,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "CONFIG_PENDING": {
+        "DEFAULT": false,
+        "FLAGS": 9,
+        "ID": "CONFIG_PENDING",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 2,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "DEVICE_IN_BOOTLOADER": {
+        "DEFAULT": false,
+        "FLAGS": 9,
+        "ID": "DEVICE_IN_BOOTLOADER",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 7,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "DUTYCYCLE": {
+        "DEFAULT": false,
+        "FLAGS": 9,
+        "ID": "DUTYCYCLE",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 4,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "LOWBAT": {
+        "DEFAULT": false,
+        "FLAGS": 9,
+        "ID": "LOWBAT",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 3,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "RSSI_DEVICE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "RSSI_DEVICE",
+        "MAX": 2147483647,
+        "MIN": -2147483648,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 5,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "RSSI_PEER": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "RSSI_PEER",
+        "MAX": 2147483647,
+        "MIN": -2147483648,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 6,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "STICKY_UNREACH": {
+        "DEFAULT": false,
+        "FLAGS": 25,
+        "ID": "STICKY_UNREACH",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 7,
+        "TAB_ORDER": 1,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "UNREACH": {
+        "DEFAULT": false,
+        "FLAGS": 9,
+        "ID": "UNREACH",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 0,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "UPDATE_PENDING": {
+        "DEFAULT": false,
+        "FLAGS": 9,
+        "ID": "UPDATE_PENDING",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 8,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      }
+    }
+  },
+  "VCU3203533:1": {
+    "LINK": {
+      "LONG_ACTION_TYPE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_ACTION_TYPE",
+        "MAX": 8,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 52,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "INACTIVE",
+          "JUMP_TO_TARGET",
+          "TOGGLE_TO_COUNTER",
+          "TOGGLE_INVERS_TO_COUNTER",
+          "UPDIM",
+          "DOWNDIM",
+          "TOGGLEDIM",
+          "TOGGLEDIM_TO_COUNTER",
+          "TOGGLEDIM_INVERS_TO_COUNTER"
+        ]
+      },
+      "LONG_COND_VALUE_HI": {
+        "DEFAULT": 100,
+        "FLAGS": 1,
+        "ID": "LONG_COND_VALUE_HI",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 44,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "LONG_COND_VALUE_LO": {
+        "DEFAULT": 50,
+        "FLAGS": 1,
+        "ID": "LONG_COND_VALUE_LO",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 43,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "LONG_CT_OFF": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_CT_OFF",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 41,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "LONG_CT_OFFDELAY": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_CT_OFFDELAY",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 39,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "LONG_CT_ON": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_CT_ON",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 42,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "LONG_CT_ONDELAY": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_CT_ONDELAY",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 40,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "LONG_CT_RAMPOFF": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_CT_RAMPOFF",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 37,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "LONG_CT_RAMPON": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_CT_RAMPON",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 38,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "LONG_DIM_MAX_LEVEL": {
+        "DEFAULT": 1.0,
+        "FLAGS": 1,
+        "ID": "LONG_DIM_MAX_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 69,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "LONG_DIM_MIN_LEVEL": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "LONG_DIM_MIN_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 68,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "LONG_DIM_STEP": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "LONG_DIM_STEP",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 70,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "LONG_JT_OFF": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "LONG_JT_OFF",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 53,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "LONG_JT_OFFDELAY": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "LONG_JT_OFFDELAY",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 55,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "LONG_JT_ON": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "LONG_JT_ON",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 54,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "LONG_JT_ONDELAY": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "LONG_JT_ONDELAY",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 56,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "LONG_JT_RAMPOFF": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "LONG_JT_RAMPOFF",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 57,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "LONG_JT_RAMPON": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "LONG_JT_RAMPON",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 58,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "LONG_MULTIEXECUTE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_MULTIEXECUTE",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 51,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "OFF",
+          "ON"
+        ]
+      },
+      "LONG_OFFDELAY_BLINK": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "LONG_OFFDELAY_BLINK",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 61,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "OFF",
+          "ON"
+        ]
+      },
+      "LONG_OFFDELAY_NEWTIME": {
+        "DEFAULT": 0.5,
+        "FLAGS": 1,
+        "ID": "LONG_OFFDELAY_NEWTIME",
+        "MAX": 25.6,
+        "MIN": 0.1,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 72,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "LONG_OFFDELAY_OLDTIME": {
+        "DEFAULT": 0.5,
+        "FLAGS": 1,
+        "ID": "LONG_OFFDELAY_OLDTIME",
+        "MAX": 25.6,
+        "MIN": 0.1,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 73,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "LONG_OFFDELAY_STEP": {
+        "DEFAULT": 0.05,
+        "FLAGS": 1,
+        "ID": "LONG_OFFDELAY_STEP",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 71,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "LONG_OFFDELAY_TIME": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "LONG_OFFDELAY_TIME",
+        "MAX": 111600.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 47,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "LONG_OFF_LEVEL": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "LONG_OFF_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 62,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "LONG_OFF_TIME": {
+        "DEFAULT": 111600.0,
+        "FLAGS": 1,
+        "ID": "LONG_OFF_TIME",
+        "MAX": 108000.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "SPECIAL": [
+          {
+            "ID": "NOT_USED",
+            "VALUE": 111600.0
+          }
+        ],
+        "TAB_ORDER": 48,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "LONG_OFF_TIME_MODE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_OFF_TIME_MODE",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 50,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "ABSOLUTE",
+          "MINIMAL"
+        ]
+      },
+      "LONG_ONDELAY_MODE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_ONDELAY_MODE",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 59,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "SET_TO_OFF",
+          "NO_CHANGE"
+        ]
+      },
+      "LONG_ONDELAY_TIME": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "LONG_ONDELAY_TIME",
+        "MAX": 111600.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 45,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "LONG_ON_LEVEL": {
+        "DEFAULT": 1.0,
+        "FLAGS": 1,
+        "ID": "LONG_ON_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "SPECIAL": [
+          {
+            "ID": "OLD_LEVEL",
+            "VALUE": 1.005
+          }
+        ],
+        "TAB_ORDER": 64,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "LONG_ON_LEVEL_PRIO": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_ON_LEVEL_PRIO",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 60,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "HIGH",
+          "LOW"
+        ]
+      },
+      "LONG_ON_MIN_LEVEL": {
+        "DEFAULT": 0.1,
+        "FLAGS": 1,
+        "ID": "LONG_ON_MIN_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 63,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "LONG_ON_TIME": {
+        "DEFAULT": 111600.0,
+        "FLAGS": 1,
+        "ID": "LONG_ON_TIME",
+        "MAX": 108000.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "SPECIAL": [
+          {
+            "ID": "NOT_USED",
+            "VALUE": 111600.0
+          }
+        ],
+        "TAB_ORDER": 46,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "LONG_ON_TIME_MODE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_ON_TIME_MODE",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 49,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "ABSOLUTE",
+          "MINIMAL"
+        ]
+      },
+      "LONG_RAMPOFF_TIME": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "LONG_RAMPOFF_TIME",
+        "MAX": 111600.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 67,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "LONG_RAMPON_TIME": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "LONG_RAMPON_TIME",
+        "MAX": 111600.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 66,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "LONG_RAMP_START_STEP": {
+        "DEFAULT": 0.05,
+        "FLAGS": 1,
+        "ID": "LONG_RAMP_START_STEP",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 65,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "SHORT_ACTION_TYPE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_ACTION_TYPE",
+        "MAX": 8,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 15,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "INACTIVE",
+          "JUMP_TO_TARGET",
+          "TOGGLE_TO_COUNTER",
+          "TOGGLE_INVERS_TO_COUNTER",
+          "UPDIM",
+          "DOWNDIM",
+          "TOGGLEDIM",
+          "TOGGLEDIM_TO_COUNTER",
+          "TOGGLEDIM_INVERS_TO_COUNTER"
+        ]
+      },
+      "SHORT_COND_VALUE_HI": {
+        "DEFAULT": 100,
+        "FLAGS": 1,
+        "ID": "SHORT_COND_VALUE_HI",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 8,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "SHORT_COND_VALUE_LO": {
+        "DEFAULT": 50,
+        "FLAGS": 1,
+        "ID": "SHORT_COND_VALUE_LO",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 7,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "SHORT_CT_OFF": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_CT_OFF",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 5,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "SHORT_CT_OFFDELAY": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_CT_OFFDELAY",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 3,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "SHORT_CT_ON": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_CT_ON",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 6,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "SHORT_CT_ONDELAY": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_CT_ONDELAY",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 4,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "SHORT_CT_RAMPOFF": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_CT_RAMPOFF",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 1,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "SHORT_CT_RAMPON": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_CT_RAMPON",
+        "MAX": 5,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 2,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "X GE COND_VALUE_LO",
+          "X GE COND_VALUE_HI",
+          "X LT COND_VALUE_LO",
+          "X LT COND_VALUE_HI",
+          "COND_VALUE_LO LE X LT COND_VALUE_HI",
+          "X LT COND_VALUE_LO OR X GE COND_VALUE_HI"
+        ]
+      },
+      "SHORT_DIM_MAX_LEVEL": {
+        "DEFAULT": 1.0,
+        "FLAGS": 1,
+        "ID": "SHORT_DIM_MAX_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 32,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "SHORT_DIM_MIN_LEVEL": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "SHORT_DIM_MIN_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 31,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "SHORT_DIM_STEP": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "SHORT_DIM_STEP",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 33,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "SHORT_JT_OFF": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "SHORT_JT_OFF",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 16,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "SHORT_JT_OFFDELAY": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "SHORT_JT_OFFDELAY",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 18,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "SHORT_JT_ON": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "SHORT_JT_ON",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 17,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "SHORT_JT_ONDELAY": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "SHORT_JT_ONDELAY",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 19,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "SHORT_JT_RAMPOFF": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "SHORT_JT_RAMPOFF",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 20,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "SHORT_JT_RAMPON": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "SHORT_JT_RAMPON",
+        "MAX": 6,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 21,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NO_JUMP_IGNORE_COMMAND",
+          "ONDELAY",
+          "RAMPON",
+          "ON",
+          "OFFDELAY",
+          "RAMPOFF",
+          "OFF"
+        ]
+      },
+      "SHORT_OFFDELAY_BLINK": {
+        "DEFAULT": 1,
+        "FLAGS": 1,
+        "ID": "SHORT_OFFDELAY_BLINK",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 24,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "OFF",
+          "ON"
+        ]
+      },
+      "SHORT_OFFDELAY_NEWTIME": {
+        "DEFAULT": 0.5,
+        "FLAGS": 1,
+        "ID": "SHORT_OFFDELAY_NEWTIME",
+        "MAX": 25.6,
+        "MIN": 0.1,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 35,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "SHORT_OFFDELAY_OLDTIME": {
+        "DEFAULT": 0.5,
+        "FLAGS": 1,
+        "ID": "SHORT_OFFDELAY_OLDTIME",
+        "MAX": 25.6,
+        "MIN": 0.1,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 36,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "SHORT_OFFDELAY_STEP": {
+        "DEFAULT": 0.05,
+        "FLAGS": 1,
+        "ID": "SHORT_OFFDELAY_STEP",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 34,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "SHORT_OFFDELAY_TIME": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "SHORT_OFFDELAY_TIME",
+        "MAX": 111600.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 11,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "SHORT_OFF_LEVEL": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "SHORT_OFF_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 25,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "SHORT_OFF_TIME": {
+        "DEFAULT": 111600.0,
+        "FLAGS": 1,
+        "ID": "SHORT_OFF_TIME",
+        "MAX": 108000.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "SPECIAL": [
+          {
+            "ID": "NOT_USED",
+            "VALUE": 111600.0
+          }
+        ],
+        "TAB_ORDER": 12,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "SHORT_OFF_TIME_MODE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_OFF_TIME_MODE",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 14,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "ABSOLUTE",
+          "MINIMAL"
+        ]
+      },
+      "SHORT_ONDELAY_MODE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_ONDELAY_MODE",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 22,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "SET_TO_OFF",
+          "NO_CHANGE"
+        ]
+      },
+      "SHORT_ONDELAY_TIME": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "SHORT_ONDELAY_TIME",
+        "MAX": 111600.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 9,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "SHORT_ON_LEVEL": {
+        "DEFAULT": 1.0,
+        "FLAGS": 1,
+        "ID": "SHORT_ON_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "SPECIAL": [
+          {
+            "ID": "OLD_LEVEL",
+            "VALUE": 1.005
+          }
+        ],
+        "TAB_ORDER": 27,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "SHORT_ON_LEVEL_PRIO": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_ON_LEVEL_PRIO",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 23,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "HIGH",
+          "LOW"
+        ]
+      },
+      "SHORT_ON_MIN_LEVEL": {
+        "DEFAULT": 0.1,
+        "FLAGS": 1,
+        "ID": "SHORT_ON_MIN_LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 26,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "SHORT_ON_TIME": {
+        "DEFAULT": 111600.0,
+        "FLAGS": 1,
+        "ID": "SHORT_ON_TIME",
+        "MAX": 108000.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "SPECIAL": [
+          {
+            "ID": "NOT_USED",
+            "VALUE": 111600.0
+          }
+        ],
+        "TAB_ORDER": 10,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "SHORT_ON_TIME_MODE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_ON_TIME_MODE",
+        "MAX": 1,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 13,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "ABSOLUTE",
+          "MINIMAL"
+        ]
+      },
+      "SHORT_RAMPOFF_TIME": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "SHORT_RAMPOFF_TIME",
+        "MAX": 111600.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 30,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "SHORT_RAMPON_TIME": {
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "SHORT_RAMPON_TIME",
+        "MAX": 111600.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 29,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "SHORT_RAMP_START_STEP": {
+        "DEFAULT": 0.05,
+        "FLAGS": 1,
+        "ID": "SHORT_RAMP_START_STEP",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 28,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "UI_HINT": {
+        "DEFAULT": "",
+        "FLAGS": 1,
+        "ID": "UI_HINT",
+        "MAX": "",
+        "MIN": "",
+        "OPERATIONS": 3,
+        "TAB_ORDER": 0,
+        "TYPE": "STRING",
+        "UNIT": ""
+      }
+    },
+    "MASTER": {
+      "AES_ACTIVE": {
+        "DEFAULT": false,
+        "FLAGS": 3,
+        "ID": "AES_ACTIVE",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 0,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      }
+    },
+    "VALUES": {
+      "DIRECTION": {
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "DIRECTION",
+        "MAX": 3,
+        "MIN": 0,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 6,
+        "TYPE": "ENUM",
+        "UNIT": "",
+        "VALUE_LIST": [
+          "NONE",
+          "UP",
+          "DOWN",
+          "UNDEFINED"
+        ]
+      },
+      "INHIBIT": {
+        "CONTROL": "NONE",
+        "DEFAULT": false,
+        "FLAGS": 1,
+        "ID": "INHIBIT",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 7,
+        "TAB_ORDER": 5,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "INSTALL_TEST": {
+        "DEFAULT": false,
+        "FLAGS": 3,
+        "ID": "INSTALL_TEST",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 7,
+        "TYPE": "ACTION",
+        "UNIT": ""
+      },
+      "LEVEL": {
+        "CONTROL": "DIMMER.LEVEL",
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "LEVEL",
+        "MAX": 1.0,
+        "MIN": 0.0,
+        "OPERATIONS": 7,
+        "TAB_ORDER": 0,
+        "TYPE": "FLOAT",
+        "UNIT": "100%"
+      },
+      "OLD_LEVEL": {
+        "CONTROL": "DIMMER.OLD_LEVEL",
+        "DEFAULT": false,
+        "FLAGS": 1,
+        "ID": "OLD_LEVEL",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 1,
+        "TYPE": "ACTION",
+        "UNIT": ""
+      },
+      "ON_TIME": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "ON_TIME",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 3,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "RAMP_STOP": {
+        "CONTROL": "NONE",
+        "DEFAULT": false,
+        "FLAGS": 1,
+        "ID": "RAMP_STOP",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 4,
+        "TYPE": "ACTION",
+        "UNIT": ""
+      },
+      "RAMP_TIME": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0.5,
+        "FLAGS": 1,
+        "ID": "RAMP_TIME",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 2,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "WORKING": {
+        "DEFAULT": false,
+        "FLAGS": 3,
+        "ID": "WORKING",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 5,
+        "TAB_ORDER": 8,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      }
+    }
+  },
+  "VCU3203533:2": {
+    "LINK": {
+      "LONG_ACT_HSV_COLOR_VALUE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_ACT_HSV_COLOR_VALUE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 1,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "SHORT_ACT_HSV_COLOR_VALUE": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_ACT_HSV_COLOR_VALUE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 0,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      }
+    },
+    "MASTER": {
+      "AES_ACTIVE": {
+        "DEFAULT": false,
+        "FLAGS": 3,
+        "ID": "AES_ACTIVE",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 0,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      }
+    },
+    "VALUES": {
+      "ACT_BRIGHTNESS": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_BRIGHTNESS",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 4,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_BRIGHTNESS_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_BRIGHTNESS_STORE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 5,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_HSV_COLOR_VALUE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_HSV_COLOR_VALUE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 6,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_HSV_COLOR_VALUE_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_HSV_COLOR_VALUE_STORE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 7,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "COLOR": {
+        "CONTROL": "RGBW_COLOR.COLOR",
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "COLOR",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 7,
+        "TAB_ORDER": 0,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "INHIBIT": {
+        "CONTROL": "NONE",
+        "DEFAULT": false,
+        "FLAGS": 1,
+        "ID": "INHIBIT",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 7,
+        "TAB_ORDER": 3,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "ON_TIME": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "ON_TIME",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 1,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "ON_TIME_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0.0,
+        "FLAGS": 3,
+        "ID": "ON_TIME_STORE",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 8,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "RAMP_TIME": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0.5,
+        "FLAGS": 1,
+        "ID": "RAMP_TIME",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 2,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "RAMP_TIME_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0.5,
+        "FLAGS": 3,
+        "ID": "RAMP_TIME_STORE",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 9,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "USER_COLOR": {
+        "CONTROL": "NONE",
+        "DEFAULT": "",
+        "FLAGS": 1,
+        "ID": "USER_COLOR",
+        "MAX": "",
+        "MIN": "",
+        "OPERATIONS": 2,
+        "TAB_ORDER": 0,
+        "TYPE": "STRING",
+        "UNIT": ""
+      }
+    }
+  },
+  "VCU3203533:3": {
+    "LINK": {
+      "LONG_ACT_COLOR_PROGRAM": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_ACT_COLOR_PROGRAM",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 3,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "LONG_ACT_MAX_BOARDER": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_ACT_MAX_BOARDER",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 5,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "LONG_ACT_MIN_BOARDER": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "LONG_ACT_MIN_BOARDER",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 4,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "SHORT_ACT_COLOR_PROGRAM": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_ACT_COLOR_PROGRAM",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 0,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "SHORT_ACT_MAX_BOARDER": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_ACT_MAX_BOARDER",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 2,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "SHORT_ACT_MIN_BOARDER": {
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "SHORT_ACT_MIN_BOARDER",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 1,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      }
+    },
+    "MASTER": {
+      "AES_ACTIVE": {
+        "DEFAULT": false,
+        "FLAGS": 3,
+        "ID": "AES_ACTIVE",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 0,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      }
+    },
+    "VALUES": {
+      "ACT_BRIGHTNESS": {
+        "CONTROL": "RGBW_AUTOMATIC.BRIGHTNESS",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_BRIGHTNESS",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 4,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_BRIGHTNESS_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_BRIGHTNESS_STORE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 5,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_COLOR_PROGRAM_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_COLOR_PROGRAM_STORE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 6,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_MAX_BOARDER": {
+        "CONTROL": "RGBW_AUTOMATIC.MAX_BOARDER",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_MAX_BOARDER",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 7,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_MAX_BORDER_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_MAX_BORDER_STORE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 8,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_MIN_BOARDER": {
+        "CONTROL": "RGBW_AUTOMATIC.MIN_BOARDER",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_MIN_BOARDER",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 9,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "ACT_MIN_BORDER_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0,
+        "FLAGS": 3,
+        "ID": "ACT_MIN_BORDER_STORE",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 10,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "INHIBIT": {
+        "CONTROL": "NONE",
+        "DEFAULT": false,
+        "FLAGS": 1,
+        "ID": "INHIBIT",
+        "MAX": true,
+        "MIN": false,
+        "OPERATIONS": 7,
+        "TAB_ORDER": 3,
+        "TYPE": "BOOL",
+        "UNIT": ""
+      },
+      "ON_TIME": {
+        "CONTROL": "RGBW_AUTOMATIC.ON_TIME",
+        "DEFAULT": 0.0,
+        "FLAGS": 1,
+        "ID": "ON_TIME",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 1,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "ON_TIME_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0.0,
+        "FLAGS": 3,
+        "ID": "ON_TIME_STORE",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 11,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "PROGRAM": {
+        "CONTROL": "RGBW_AUTOMATIC.PROGRAM",
+        "DEFAULT": 0,
+        "FLAGS": 1,
+        "ID": "PROGRAM",
+        "MAX": 255,
+        "MIN": 0,
+        "OPERATIONS": 7,
+        "TAB_ORDER": 0,
+        "TYPE": "INTEGER",
+        "UNIT": ""
+      },
+      "RAMP_TIME": {
+        "CONTROL": "RGBW_AUTOMATIC.RAMP_TIME",
+        "DEFAULT": 0.5,
+        "FLAGS": 1,
+        "ID": "RAMP_TIME",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 3,
+        "TAB_ORDER": 2,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "RAMP_TIME_STORE": {
+        "CONTROL": "NONE",
+        "DEFAULT": 0.5,
+        "FLAGS": 3,
+        "ID": "RAMP_TIME_STORE",
+        "MAX": 85825945.6,
+        "MIN": 0.0,
+        "OPERATIONS": 2,
+        "TAB_ORDER": 12,
+        "TYPE": "FLOAT",
+        "UNIT": "s"
+      },
+      "USER_PROGRAM": {
+        "CONTROL": "NONE",
+        "DEFAULT": "",
+        "FLAGS": 1,
+        "ID": "USER_PROGRAM",
+        "MAX": "",
+        "MIN": "",
+        "OPERATIONS": 2,
+        "TAB_ORDER": 0,
+        "TYPE": "STRING",
+        "UNIT": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION
add device support for https://github.com/jp112sdl/HB-UNI-RGB-LED-CTRL
not sure that all homebrew devices are wanted in the new integration, but would be helpfull at least for me. :-)