### PR TITLE
chore(ci): harden CI supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+---
+# Dependabot configuration
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Keep GitHub Actions (pinned to commit SHAs) up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "SukramJ"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Keep Python dependencies up to date (grouped to reduce PR noise).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "SukramJ"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -75,7 +75,8 @@ jobs:
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        # yamllint disable-line rule:line-length
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           name: ${{ github.ref_name }}
           body_path: release_notes.txt
@@ -99,6 +100,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # yamllint disable-line rule:line-length
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: dist/

--- a/.github/workflows/test-run.yaml
+++ b/.github/workflows/test-run.yaml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v4
+        # yamllint disable-line rule:line-length
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4
         with:
           files: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions supply chain for this repository.

### Pin third-party actions to full commit SHAs

Mutable tag/branch refs are replaced with immutable 40-char commit SHAs (with a human-readable `# vX` comment). `actions/*` and `github/codeql-action/*` are intentionally left on tags.

| Action | Previous ref | Pinned SHA |
| --- | --- | --- |
| `codecov/codecov-action` | `v4` | `b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238` |
| `softprops/action-gh-release` | `v2` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |
| `pypa/gh-action-pypi-publish` | `release/v1` (mutable **branch** ref) | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` |

The `pypa/gh-action-pypi-publish` ref is especially important: `release/v1` is a moving **branch**, so any compromise of that branch would have flowed straight into the PyPI publish job.

A `# yamllint disable-line rule:line-length` directive (an existing repo convention) precedes each pinned line because a 40-char SHA exceeds the 80-char yamllint limit.

### Add Dependabot configuration

New `.github/dependabot.yml` keeps both the pinned actions and Python deps current:

- `github-actions` ecosystem, weekly, grouped, reviewer `SukramJ`, `dependencies` label, `chore` commit prefix.
- `pip` ecosystem, weekly, grouped (formalizes existing bump PRs), `dependencies` + `python` labels.

### Notes

- Branched from and targets `master` (intentional default branch for now); no `master`/`devel` self-references were rewritten.
- No stale `devel` references were found.
- yamllint validated locally; pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)